### PR TITLE
chore(deps): 調整 Dependabot 群組與 Node major 忽略

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,8 +18,23 @@ updates:
     directory: /
     schedule:
       interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Asia/Taipei
+    groups:
+      github-actions:
+        patterns:
+          - "*"
 
   - package-ecosystem: docker
     directory: /
     schedule:
       interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Asia/Taipei
+    ignore:
+      # CI image stays on Node 22; major bumps (e.g. 22 → 26) are intentional upgrades only
+      - dependency-name: node
+        update-types:
+          - version-update:semver-major


### PR DESCRIPTION
- github-actions：每週單一 PR 打包所有 action 更新
- docker：忽略 node 的 semver-major，避免自動開 22→26 類 PR
- actions / docker 排程與 npm 對齊（週一 09:00 Asia/Taipei）